### PR TITLE
Fix missing semicolon in consts

### DIFF
--- a/src/consts.ts
+++ b/src/consts.ts
@@ -1,4 +1,4 @@
 export const SITE_TITLE = "BOLSTA TECH";
 export const SITE_DESCRIPTION = "モダンなWeb制作を極めるテックブログ。Astro、Tailwind CSS、HTML/CSSの最新テクニックから、パフォーマンス改善、アクセシビリティ、ユーザービリティまで、プロが実践するノウハウをわかりやすく解説します。";
-export const X_URL = "https://x.com/shoirhi"
+export const X_URL = "https://x.com/shoirhi";
 export const GITHUB_URL = "https://github.com/shoirhi";


### PR DESCRIPTION
## Summary
- end each exported constant in `consts.ts` with a semicolon

## Testing
- `npm run build` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855030df040832f8c0b5869e642c25f